### PR TITLE
Update Fluent-Terminal to v0.6.0.0

### DIFF
--- a/manual/fluent-terminal/download.cmd
+++ b/manual/fluent-terminal/download.cmd
@@ -1,1 +1,1 @@
-curl -L https://github.com/felixse/FluentTerminal/releases/download/0.5.3.0/FluentTerminal.App_0.5.3.0_Test.zip --output tools\FluentTerminal.App_0.5.3.0_Test.zip
+curl -L https://github.com/felixse/FluentTerminal/releases/download/0.6.0.0/FluentTerminal.Package_0.6.0.0_Test.zip --output tools\FluentTerminal.App_0.6.0.0_Test.zip

--- a/manual/fluent-terminal/fluent-terminal.nuspec
+++ b/manual/fluent-terminal/fluent-terminal.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>fluent-terminal</id>
-    <version>0.5.3.0</version>
+    <version>0.6.0.0</version>
     <packageSourceUrl>https://github.com/pgalbraith/chocolatey-packages</packageSourceUrl>
     <owners>mooglie</owners>
     <title>Fluent Terminal</title>
@@ -24,7 +24,7 @@ A Terminal Emulator based on UWP and web technologies. Note that this is a sidel
 
 This package will turn on [App Sideloading](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development) on the installation machine.  *Please note that this feature will not be disabled upon uninstalling this package*.  If you wish you disable [App Sideloading](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development) after uninstalling this package, you must do so manually.
     </description>
-    <releaseNotes>https://github.com/felixse/FluentTerminal/releases/tag/0.5.3.0</releaseNotes>
+    <releaseNotes>https://github.com/felixse/FluentTerminal/releases/tag/0.6.0.0</releaseNotes>
     <dependencies>
       <dependency id="PowerShell" />
     </dependencies>

--- a/manual/fluent-terminal/tools/VERIFICATION.txt
+++ b/manual/fluent-terminal/tools/VERIFICATION.txt
@@ -1,3 +1,3 @@
 To verify, compare with the binary from the author's official distribution point:
 
-https://github.com/felixse/FluentTerminal/releases/tag/0.5.3.0
+https://github.com/felixse/FluentTerminal/releases/tag/0.6.0.0

--- a/manual/fluent-terminal/tools/chocolateyinstall.ps1
+++ b/manual/fluent-terminal/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'; # stop on all errors
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $installDir = "$env:ChocolateyPackageFolder\install"
-$packageZip = "$toolsDir\FluentTerminal.App_0.5.3.0_Test.zip"
+$packageZip = "$toolsDir\FluentTerminal.App_0.6.0.0_Test.zip"
 
 # The following version check code is lifted straight from the 'powershell' install script
 


### PR DESCRIPTION
Hello,

I updated the fluent-terminal package to [v0.6.0.0](https://github.com/felixse/FluentTerminal/releases/tag/0.6.0.0).

Note some people might prefer to stick with v0.5.3.0 since v0.6.0.0 has a critical bug : https://github.com/felixse/FluentTerminal/issues/528 . If you're affected by this bug, you need to uninstall fluent-terminal first then ask specificially for version 0.5.3.0:

```ps
 choco uninstall fluent-terminal
 choco install fluent-terminal --version 0.5.3.0
```

I tried downgrading, but Windows did not like that. [PR opened](https://github.com/felixse/FluentTerminal/pull/535) in upstream to address this issue.
<details>
<summary>Installation logs</summary>

```
PS> choco install fluent-terminal  --version 0.5.3.0 --allow-downgrade

Chocolatey v0.10.15
Installing the following packages:
fluent-terminal
By installing you accept licenses for the packages.
Progress: Downloading fluent-terminal 0.5.3.0... 100%

fluent-terminal v0.5.3.0 [Approved]
fluent-terminal package files install completed. Performing other installation steps.
Running on: Windows 10 Enterprise, (Enterprise), Windows Kernel: 10.0.17134
Enabling App Sideloading
The operation completed successfully.

Extracting C:\ProgramData\chocolatey\lib\fluent-terminal\tools\FluentTerminal.App_0.5.3.0_Test.zip to C:\ProgramData\chocolatey\lib\fluent-terminal\install...
C:\ProgramData\chocolatey\lib\fluent-terminal\install
Found bundle: C:\ProgramData\chocolatey\lib\fluent-terminal\install\FluentTerminal.App_0.5.3.0_x86_x64.appxbundle

Installing app...
Found dependency package(s):
C:\ProgramData\chocolatey\lib\fluent-terminal\install\Dependencies\x86\Microsoft.NET.Native.Framework.2.2.appx
C:\ProgramData\chocolatey\lib\fluent-terminal\install\Dependencies\x86\Microsoft.NET.Native.Runtime.2.2.appx
C:\ProgramData\chocolatey\lib\fluent-terminal\install\Dependencies\x86\Microsoft.VCLibs.x86.14.00.appx
C:\ProgramData\chocolatey\lib\fluent-terminal\install\Dependencies\x64\Microsoft.NET.Native.Framework.2.2.appx
C:\ProgramData\chocolatey\lib\fluent-terminal\install\Dependencies\x64\Microsoft.NET.Native.Runtime.2.2.appx
C:\ProgramData\chocolatey\lib\fluent-terminal\install\Dependencies\x64\Microsoft.VCLibs.x64.14.00.appx
Progress: 0% - Processing
Deployment failed with HRESULT: 0x80073D06, The package could not be installed because a higher version of this package is already installed.

Windows cannot install package 53621FSApps.FluentTerminal_0.5.3.0_x64__87x1pks76srcp because it has version 0.5.3.0. A higher version 0.6.0.0 of this package is already installed.

NOTE: For additional information, look for [ActivityId] 63dd33ec-782a-0007-1798-dd632a78d501 in the Event Log or use the command line Get-AppxLog -ActivityID 63dd33ec-782a-0007-1798-dd632a78d501

Error: Could not install the app.
The install of fluent-terminal was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\fluent-terminal\tools\chocolateyinstall.ps1'.
 See log for details.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - fluent-terminal (exited 1) - Error while running 'C:\ProgramData\chocolatey\lib\fluent-terminal\tools\chocolateyinstall.ps1'.
 See log for details.
```